### PR TITLE
Refactor Entity Search API: Update Query Structure and Parameters for search_entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 =======
 
 
+## [0.2.19] - 2025-06-30
+
+### Changed
+- `get_entities` now returns also the blueprint identifier for consistency.
+
+### Fixed
+- `get_entities` tool now returns proper results when called with `details=False`.
+
 ## [0.2.18] - 2025-06-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-port"
-version = "0.2.18"
+version = "0.2.19"
 authors = [
   { name = "Matan Grady", email = "matan.grady@getport.io" }
 ]
@@ -32,7 +32,7 @@ include = [
 ]
 [tool.poetry]
 name = "mcp-server-port"
-version = "0.2.17"
+version = "0.2.19"
 description = "Port's MCP server"
 packages = [
     { include = "src" }

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -122,8 +122,19 @@ class PortClient:
     async def get_entities(self, blueprint_identifier: str) -> list[EntityResult]:
         return await self.wrap_request(lambda: self.entities.get_entities(blueprint_identifier))
 
-    async def search_entities(self, blueprint_identifier: str, search_query: dict[str, Any]) -> list[EntityResult]:
-        return await self.wrap_request(lambda: self.entities.search_entities(blueprint_identifier, search_query))
+    async def search_entities(
+        self, 
+        blueprint_identifier: str, 
+        query: dict[str, Any] | None = None,
+        include: list[str] | None = None,
+        limit: int = 200
+    ) -> list[EntityResult]:
+        return await self.wrap_request(lambda: self.entities.search_entities(
+            blueprint_identifier=blueprint_identifier,
+            query=query,
+            include=include,
+            limit=limit
+        ))
 
     async def create_entity(
         self, blueprint_identifier: str, entity_data: dict[str, Any], query: dict[str, Any]

--- a/src/client/entities.py
+++ b/src/client/entities.py
@@ -35,11 +35,9 @@ class PortEntityClient:
 
         response_data = self._client.entities.search_blueprint_entities(blueprint_identifier, search_query)
         
-        # Extract entities from the response dictionary
         entities_data = response_data.get("entities", [])
 
         logger.info(f"Got {len(entities_data)} entities for blueprint '{blueprint_identifier}' from Port")
-        logger.debug(f"Response for search entities: {response_data}")
         if config.api_validation_enabled:
             logger.debug("Validating entities")
             return [EntityResult(**entity_data) for entity_data in entities_data]

--- a/src/client/entities.py
+++ b/src/client/entities.py
@@ -33,10 +33,13 @@ class PortEntityClient:
         logger.info(f"Searching entities for blueprint '{blueprint_identifier}' from Port")
         logger.debug(f"Search query: {search_query}")
 
-        entities_data = self._client.entities.search_blueprint_entities(blueprint_identifier, search_query)
+        response_data = self._client.entities.search_blueprint_entities(blueprint_identifier, search_query)
+        
+        # Extract entities from the response dictionary
+        entities_data = response_data.get("entities", [])
 
         logger.info(f"Got {len(entities_data)} entities for blueprint '{blueprint_identifier}' from Port")
-        logger.debug(f"Response for search entities: {entities_data}")
+        logger.debug(f"Response for search entities: {response_data}")
         if config.api_validation_enabled:
             logger.debug("Validating entities")
             return [EntityResult(**entity_data) for entity_data in entities_data]

--- a/src/tools/entity/get_entities.py
+++ b/src/tools/entity/get_entities.py
@@ -50,23 +50,24 @@ class GetEntitiesTool(Tool[GetEntitiesToolSchema]):
 
         detailed = args.get("detailed", False)
         
-        search_query = {
-            "query": {
-                "combinator": "and",
-                "rules": [
-                    {
-                        "property": "$blueprint",
-                        "operator": "=",
-                        "value": blueprint_identifier
-                    }
-                ]
-            }
+        query = {
+            "combinator": "and",
+            "rules": [
+                {
+                    "property": "$blueprint",
+                    "operator": "=",
+                    "value": blueprint_identifier
+                }
+            ]
         }
         
-        if not detailed:
-            search_query["include"] = ["identifier", "title"]
+        include = ["$identifier", "$title"] if not detailed else None
 
-        raw_entities = await self.port_client.search_entities(blueprint_identifier, search_query)
+        raw_entities = await self.port_client.search_entities(
+            blueprint_identifier=blueprint_identifier,
+            query=query,
+            include=include
+        )
         
         processed_entities = []
         for entity in raw_entities:

--- a/src/tools/entity/get_entities.py
+++ b/src/tools/entity/get_entities.py
@@ -52,15 +52,27 @@ class GetEntitiesTool(Tool[GetEntitiesToolSchema]):
         
         search_query = {
             "query": {
-                "$blueprint": {"=": blueprint_identifier}
+                "combinator": "and",
+                "rules": [
+                    {
+                        "property": "$blueprint",
+                        "operator": "=",
+                        "value": blueprint_identifier
+                    }
+                ]
             }
         }
         
         if not detailed:
-            search_query["include"] = ["$identifier", "$title"]
+            search_query["include"] = ["identifier", "title"]
 
         raw_entities = await self.port_client.search_entities(blueprint_identifier, search_query)
-        processed_entities = [entity.model_dump(exclude_unset=True, exclude_none=True) for entity in raw_entities]
+        
+        processed_entities = []
+        for entity in raw_entities:
+            entity_dict = entity.model_dump(exclude_unset=True, exclude_none=True)
+            entity_dict["blueprint"] = blueprint_identifier
+            processed_entities.append(entity_dict)
 
-        response = GetEntitiesToolResponse.construct(entities=processed_entities)
+        response = GetEntitiesToolResponse(entities=processed_entities)
         return response.model_dump(exclude_unset=True, exclude_none=True)

--- a/tests/unit/tools/entity/test_get_entities.py
+++ b/tests/unit/tools/entity/test_get_entities.py
@@ -23,7 +23,6 @@ async def test_get_entities_tool_detailed_true(mock_client_with_entities):
     result = await tool.get_entities(tool.validate_input(schema))
     
     expected_query = {
-        "query": {
             "combinator": "and",
             "rules": [
                 {
@@ -33,8 +32,11 @@ async def test_get_entities_tool_detailed_true(mock_client_with_entities):
                 }
             ]
         }
-    }
-    mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
+    mock_client_with_entities.search_entities.assert_awaited_once_with(
+        blueprint_identifier="test-blueprint", 
+        query=expected_query, 
+        include=None
+    )
     assert result is not None
     assert "entities" in result
     assert result["entities"][0]["blueprint"] == "test-blueprint"
@@ -49,19 +51,20 @@ async def test_get_entities_tool_detailed_false(mock_client_with_entities):
     result = await tool.get_entities(tool.validate_input(schema))
     
     expected_query = {
-        "query": {
-            "combinator": "and",
-            "rules": [
-                {
-                    "property": "$blueprint",
-                    "operator": "=",
-                    "value": "test-blueprint"
-                }
-            ]
-        },
-        "include": ["identifier", "title"]
+        "combinator": "and",
+        "rules": [
+            {
+                "property": "$blueprint",
+                "operator": "=",
+                "value": "test-blueprint"
+            }
+        ]
     }
-    mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
+    mock_client_with_entities.search_entities.assert_awaited_once_with(
+        blueprint_identifier="test-blueprint", 
+        query=expected_query, 
+        include=["$identifier", "$title"]
+    )
     assert result is not None
     assert "entities" in result
     assert result["entities"][0]["blueprint"] == "test-blueprint"
@@ -76,19 +79,20 @@ async def test_get_entities_tool_default_detailed(mock_client_with_entities):
     result = await tool.get_entities(tool.validate_input(schema))
     
     expected_query = {
-        "query": {
-            "combinator": "and",
-            "rules": [
-                {
-                    "property": "$blueprint",
-                    "operator": "=",
-                    "value": "test-blueprint"
-                }
-            ]
-        },
-        "include": ["identifier", "title"]
+        "combinator": "and",
+        "rules": [
+            {
+                "property": "$blueprint",
+                "operator": "=",
+                "value": "test-blueprint"
+            }
+        ]
     }
-    mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
+    mock_client_with_entities.search_entities.assert_awaited_once_with(
+        blueprint_identifier="test-blueprint", 
+        query=expected_query, 
+        include=["$identifier", "$title"]
+    )
     assert result is not None
     assert "entities" in result
     assert result["entities"][0]["blueprint"] == "test-blueprint"

--- a/tests/unit/tools/entity/test_get_entities.py
+++ b/tests/unit/tools/entity/test_get_entities.py
@@ -7,7 +7,7 @@ from src.tools.entity import GetEntitiesTool
 @pytest.fixture
 def mock_client_with_entities(mock_client):
     """Add specific return values for this test"""
-    mock_client.search_entities.return_value = [EntityResult(identifier="test-entity", blueprint="test-blueprint")]
+    mock_client.search_entities.return_value = [EntityResult(identifier="test-entity", blueprint="test-blueprint", title="Test Entity")]
     return mock_client
 
 
@@ -22,10 +22,22 @@ async def test_get_entities_tool_detailed_true(mock_client_with_entities):
     schema = {"blueprint_identifier": "test-blueprint", "detailed": True}
     result = await tool.get_entities(tool.validate_input(schema))
     
-    # Verify search_entities was called with correct query (no include filter for detailed=True)
-    expected_query = {"query": {"$blueprint": {"=": "test-blueprint"}}}
+    expected_query = {
+        "query": {
+            "combinator": "and",
+            "rules": [
+                {
+                    "property": "$blueprint",
+                    "operator": "=",
+                    "value": "test-blueprint"
+                }
+            ]
+        }
+    }
     mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
     assert result is not None
+    assert "entities" in result
+    assert result["entities"][0]["blueprint"] == "test-blueprint"
 
 
 @pytest.mark.asyncio
@@ -36,13 +48,23 @@ async def test_get_entities_tool_detailed_false(mock_client_with_entities):
     schema = {"blueprint_identifier": "test-blueprint", "detailed": False}
     result = await tool.get_entities(tool.validate_input(schema))
     
-    # Verify search_entities was called with correct query (include filter for detailed=False)
     expected_query = {
-        "query": {"$blueprint": {"=": "test-blueprint"}},
-        "include": ["$identifier", "$title"]
+        "query": {
+            "combinator": "and",
+            "rules": [
+                {
+                    "property": "$blueprint",
+                    "operator": "=",
+                    "value": "test-blueprint"
+                }
+            ]
+        },
+        "include": ["identifier", "title"]
     }
     mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
     assert result is not None
+    assert "entities" in result
+    assert result["entities"][0]["blueprint"] == "test-blueprint"
 
 
 @pytest.mark.asyncio
@@ -53,10 +75,20 @@ async def test_get_entities_tool_default_detailed(mock_client_with_entities):
     schema = {"blueprint_identifier": "test-blueprint"}
     result = await tool.get_entities(tool.validate_input(schema))
     
-    # Verify search_entities was called with correct query (include filter for default detailed=False)
     expected_query = {
-        "query": {"$blueprint": {"=": "test-blueprint"}},
-        "include": ["$identifier", "$title"]
+        "query": {
+            "combinator": "and",
+            "rules": [
+                {
+                    "property": "$blueprint",
+                    "operator": "=",
+                    "value": "test-blueprint"
+                }
+            ]
+        },
+        "include": ["identifier", "title"]
     }
     mock_client_with_entities.search_entities.assert_awaited_once_with("test-blueprint", expected_query)
     assert result is not None
+    assert "entities" in result
+    assert result["entities"][0]["blueprint"] == "test-blueprint"


### PR DESCRIPTION
This PR refactors the entity search functionality to align with updated API requirements and improve flexibility:

- Updates the `search_entities` method in both `PortClient` and `PortEntityClient` to accept a more expressive query structure (`combinator` and `rules`), an optional `include` list, and a `limit` parameter.
- Adjusts the request body sent to the backend to match the new API spec, supporting advanced filtering and field selection.
- Refactors the `GetEntitiesTool` to use the new query format and pass the correct parameters for detailed and non-detailed entity retrieval.
- Updates unit tests for `GetEntitiesTool` to verify the new query structure and parameter passing, ensuring correct behavior for both detailed and non-detailed requests.

Fixes #57 .